### PR TITLE
Add trigonometric functions & more

### DIFF
--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -244,6 +244,35 @@ struct Sin: Expression {
     }
 }
 
+struct Cos: Expression {
+    let arg: Expression
+    
+    func evalWithData(_ data: JSON?) throws -> JSON {
+        let jsonValue = try arg.evalWithData(data)
+        
+        if case let JSON.Array(array) = try arg.evalWithData(data) {
+            guard array.count > 1 else {
+                return array.first?.double.flatMap(cos).flatMap(JSON.Double) ??
+                    array.first?.int.flatMap(Double.init).flatMap(cos).flatMap(JSON.Double) ??
+                    JSON.Null
+            }
+            
+            return JSON.Array(array.compactMap { value in
+                return value.double.flatMap(cos).flatMap(JSON.Double) ??
+                    value.int.flatMap(Double.init).flatMap(cos).flatMap(JSON.Double)
+            })
+        } else if case let JSON.Int(number) = jsonValue {
+            let sinValue = cos(Double(number))
+            return JSON.Double(sinValue)
+        } else if case let JSON.Double(number) = jsonValue {
+            return JSON.Double(cos(number))
+        } else {
+            return JSON.Null
+        }
+    }
+
+}
+
 struct Max: Expression {
     let arg: Expression
 

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -766,6 +766,8 @@ class Parser {
             return Comparison(arg: try self.parse(json: value), operation: >=)
         case "<=":
             return Comparison(arg: try self.parse(json: value), operation: <=)
+        case "rnd":
+            return Round(arg: try self.parse(json: value))
         case "if", "?:":
             guard let array = try self.parse(json: value) as? ArrayOfExpressions else {
                 throw ParseError.GenericError("\(key) statement be followed by an array")

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -735,6 +735,8 @@ class Parser {
             return Min(arg: try self.parse(json: value))
         case "sin":
             return Sin(arg: try self.parse(json: value))
+        case "cos":
+            return Cos(arg: try self.parse(json: value))
         case "substr":
             guard let array = try self.parse(json: value) as? ArrayOfExpressions else {
                 throw ParseError.GenericError("\(key) statement be followed by an array")

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -159,6 +159,26 @@ struct Comparison: Expression {
     }
 }
 
+struct Round: Expression {
+    let arg: Expression
+    
+    func evalWithData(_ data: JSON?) throws -> JSON {
+        let result = try arg.evalWithData(data)
+        switch result {
+        case let .Array(array) where array.count == 2:
+            guard let numberToRound = array[0].double,
+                  let numberOfPlaces = array[1].int
+            else { fallthrough }
+            
+            let divisor = pow(10.0, Double(numberOfPlaces))
+            let result = (numberToRound * divisor).rounded() / divisor
+            return .Double(result)
+        default:
+            return result.toNumber()
+        }
+    }
+}
+
 //swiftlint:disable:next type_name
 struct If: Expression {
     let arg: ArrayOfExpressions

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -216,6 +216,23 @@ struct Not: Expression {
     }
 }
 
+struct Sin: Expression {
+    let arg: Expression
+    
+    func evalWithData(_ data: JSON?) throws -> JSON {
+        let jsonValue = try arg.evalWithData(data)
+        
+        if case let JSON.Int(number) = jsonValue {
+            let sinValue = sin(Double(number))
+            return JSON.Double(sinValue)
+        } else if case let JSON.Double(number) = jsonValue {
+            return JSON.Double(sin(number))
+        } else {
+            return JSON.Null
+        }
+    }
+}
+
 struct Max: Expression {
     let arg: Expression
 

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -179,6 +179,36 @@ struct Round: Expression {
     }
 }
 
+struct CastToNumber: Expression {
+    let arg: Expression
+    
+    func evalWithData(_ data: JSON?) throws -> JSON {
+        let result = try arg.evalWithData(data)
+        
+        switch result {
+        case let .Array(array):
+            let stringArray = array.compactMap { element -> String? in
+                switch element {
+                case .String(let value):
+                    return value
+                default:
+                    return nil
+                }
+            }
+            
+            guard stringArray.isEmpty == false else { return .Null }
+            
+            return .Array(stringArray.compactMap(Double.init).map(JSON.Double))
+        case let .String(string):
+            guard let value = Double(string) else { return .Null }
+            
+            return .Double(value)
+        default:
+            return .Null
+        }
+    }
+}
+
 //swiftlint:disable:next type_name
 struct If: Expression {
     let arg: ArrayOfExpressions

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -222,7 +222,18 @@ struct Sin: Expression {
     func evalWithData(_ data: JSON?) throws -> JSON {
         let jsonValue = try arg.evalWithData(data)
         
-        if case let JSON.Int(number) = jsonValue {
+        if case let JSON.Array(array) = try arg.evalWithData(data) {
+            guard array.count > 1 else {
+                return array.first?.double.flatMap(sin).flatMap(JSON.Double) ??
+                    array.first?.int.flatMap(Double.init).flatMap(sin).flatMap(JSON.Double) ??
+                    JSON.Null
+            }
+            
+            return JSON.Array(array.compactMap { value in
+                return value.double.flatMap(sin).flatMap(JSON.Double) ??
+                    value.int.flatMap(Double.init).flatMap(sin).flatMap(JSON.Double)
+            })
+        } else if case let JSON.Int(number) = jsonValue {
             let sinValue = sin(Double(number))
             return JSON.Double(sinValue)
         } else if case let JSON.Double(number) = jsonValue {

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -198,7 +198,15 @@ struct CastToNumber: Expression {
             
             guard stringArray.isEmpty == false else { return .Null }
             
-            return .Array(stringArray.compactMap(Double.init).map(JSON.Double))
+            let doubleArray = stringArray.compactMap(Double.init).map(JSON.Double)
+            
+            guard doubleArray.isEmpty == false else { return .Null }
+            
+            if doubleArray.count == 1 {
+                return doubleArray[0]
+            }
+            
+            return .Array(doubleArray)
         case let .String(string):
             guard let value = Double(string) else { return .Null }
             

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -798,6 +798,8 @@ class Parser {
             return Comparison(arg: try self.parse(json: value), operation: <=)
         case "rnd":
             return Round(arg: try self.parse(json: value))
+        case "num":
+            return CastToNumber(arg: try self.parse(json: value))
         case "if", "?:":
             guard let array = try self.parse(json: value) as? ArrayOfExpressions else {
                 throw ParseError.GenericError("\(key) statement be followed by an array")

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -693,6 +693,8 @@ class Parser {
              return Max(arg: try self.parse(json: value))
         case "min":
             return Min(arg: try self.parse(json: value))
+        case "sin":
+            return Sin(arg: try self.parse(json: value))
         case "substr":
             guard let array = try self.parse(json: value) as? ArrayOfExpressions else {
                 throw ParseError.GenericError("\(key) statement be followed by an array")

--- a/Tests/jsonlogicTests/ArithmeticTests.swift
+++ b/Tests/jsonlogicTests/ArithmeticTests.swift
@@ -208,7 +208,7 @@ class Arithmetic: XCTestCase {
         
         rule =
         """
-        { "cos": [\(Double.pi)] }
+        { "cos": [\(2 * Double.pi)] }
         """
         
         XCTAssertEqual(1, try applyRule(rule, to: nil), accuracy: 0.002)

--- a/Tests/jsonlogicTests/ArithmeticTests.swift
+++ b/Tests/jsonlogicTests/ArithmeticTests.swift
@@ -193,23 +193,23 @@ class Arithmetic: XCTestCase {
     
     func testCos() {
         var rule =
-        """
-        { "cos": [\(Double.pi / 2)] }
-        """
+                """
+                { "cos": [\(Double.pi / 2)] }
+                """
         
         XCTAssertEqual(0, try applyRule(rule, to: nil), accuracy: 0.002)
         
         rule =
-        """
-        { "cos": [\(Double.pi / 3)] }
-        """
+                """
+                { "cos": [\(Double.pi / 3)] }
+                """
         
         XCTAssertEqual(0.5, try applyRule(rule, to: nil), accuracy: 0.002)
         
         rule =
-        """
-        { "cos": [\(2 * Double.pi)] }
-        """
+                """
+                { "cos": [\(2 * Double.pi)] }
+                """
         
         XCTAssertEqual(1, try applyRule(rule, to: nil), accuracy: 0.002)
     }

--- a/Tests/jsonlogicTests/ArithmeticTests.swift
+++ b/Tests/jsonlogicTests/ArithmeticTests.swift
@@ -192,5 +192,25 @@ class Arithmetic: XCTestCase {
     }
     
     func testCos() {
+        var rule =
+        """
+        { "cos": [\(Double.pi / 2)] }
+        """
+        
+        XCTAssertEqual(0, try applyRule(rule, to: nil), accuracy: 0.002)
+        
+        rule =
+        """
+        { "cos": [\(Double.pi / 3)] }
+        """
+        
+        XCTAssertEqual(0.5, try applyRule(rule, to: nil), accuracy: 0.002)
+        
+        rule =
+        """
+        { "cos": [\(Double.pi)] }
+        """
+        
+        XCTAssertEqual(1, try applyRule(rule, to: nil), accuracy: 0.002)
     }
 }

--- a/Tests/jsonlogicTests/ArithmeticTests.swift
+++ b/Tests/jsonlogicTests/ArithmeticTests.swift
@@ -171,9 +171,26 @@ class Arithmetic: XCTestCase {
     func testSin() {
         var rule =
                 """
-                { "sin": [1.57079632679] }
+                { "sin": [\(Double.pi / 2)] }
                 """
         
         XCTAssertEqual(1, try applyRule(rule, to: nil), accuracy: 0.002)
+        
+        rule =
+                """
+                { "sin": [\(Double.pi / 6)] }
+                """
+        
+        XCTAssertEqual(0.5, try applyRule(rule, to: nil), accuracy: 0.002)
+        
+        rule =
+                """
+                { "sin": [\(Double.pi)] }
+                """
+        
+        XCTAssertEqual(0, try applyRule(rule, to: nil), accuracy: 0.002)
+    }
+    
+    func testCos() {
     }
 }

--- a/Tests/jsonlogicTests/ArithmeticTests.swift
+++ b/Tests/jsonlogicTests/ArithmeticTests.swift
@@ -241,6 +241,8 @@ class Arithmetic: XCTestCase {
         { "tan": [\(Double.pi / 2)] }
         """
         
-        XCTAssertEqual(.nan, try applyRule(rule, to: nil), accuracy: 0.002)
+        // In mathematics, this would be undefined
+        // In a programming language using IEEE 754, this is "a very large number"
+        XCTAssertGreaterThan(try applyRule(rule, to: nil), 1.5e16)
     }
 }

--- a/Tests/jsonlogicTests/ArithmeticTests.swift
+++ b/Tests/jsonlogicTests/ArithmeticTests.swift
@@ -167,4 +167,13 @@ class Arithmetic: XCTestCase {
                 """
         XCTAssertEqual(2, try applyRule(rule, to: nil))
     }
+    
+    func testSin() {
+        var rule =
+                """
+                { "sin": [1.57079632679] }
+                """
+        
+        XCTAssertEqual(1, try applyRule(rule, to: nil), accuracy: 0.002)
+    }
 }

--- a/Tests/jsonlogicTests/ArithmeticTests.swift
+++ b/Tests/jsonlogicTests/ArithmeticTests.swift
@@ -213,4 +213,34 @@ class Arithmetic: XCTestCase {
         
         XCTAssertEqual(1, try applyRule(rule, to: nil), accuracy: 0.002)
     }
+    
+    func testTan() {
+        var rule =
+        """
+        { "tan": [0] }
+        """
+        
+        XCTAssertEqual(0, try applyRule(rule, to: nil), accuracy: 0.002)
+        
+        rule =
+        """
+        { "tan": [\(Double.pi / 3)] }
+        """
+        
+        XCTAssertEqual(sqrt(3), try applyRule(rule, to: nil), accuracy: 0.002)
+        
+        rule =
+        """
+        { "tan": [\(Double.pi / 4)] }
+        """
+        
+        XCTAssertEqual(1, try applyRule(rule, to: nil), accuracy: 0.002)
+        
+        rule =
+        """
+        { "tan": [\(Double.pi / 2)] }
+        """
+        
+        XCTAssertEqual(.nan, try applyRule(rule, to: nil), accuracy: 0.002)
+    }
 }

--- a/Tests/jsonlogicTests/NumberCastTests.swift
+++ b/Tests/jsonlogicTests/NumberCastTests.swift
@@ -1,0 +1,36 @@
+//
+//  NumberCastTests.swift
+//  jsonlogicTests
+//
+//  Created by Dino on 22/07/2019.
+//
+
+import XCTest
+@testable import jsonlogic
+
+class NumberCastTests: XCTestCase {
+
+    func testCastNumericalString() {
+        var rule =
+        """
+        { "num": ["0"] }
+        """
+        
+        XCTAssertEqual(0, try applyRule(rule, to: nil), accuracy: 0.002)
+        
+        rule =
+        """
+        { "num": ["0.145"] }
+        """
+        
+        XCTAssertEqual(0.145, try applyRule(rule, to: nil), accuracy: 0.002)
+
+        rule =
+        """
+        { "num": ["3.14159"] }
+        """
+        
+        XCTAssertEqual(Double.pi, try applyRule(rule, to: nil), accuracy: 0.002)
+    }
+
+}

--- a/Tests/jsonlogicTests/NumberCastTests.swift
+++ b/Tests/jsonlogicTests/NumberCastTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import JSON
 @testable import jsonlogic
 
 class NumberCastTests: XCTestCase {
@@ -31,6 +32,43 @@ class NumberCastTests: XCTestCase {
         """
         
         XCTAssertEqual(Double.pi, try applyRule(rule, to: nil), accuracy: 0.002)
+    }
+    
+    func testCastInvalidString() {
+        var rule =
+        """
+        { "num": ["Hello World"] }
+        """
+        
+        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "num": ["0.14AF"] }
+        """
+        
+        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
+
+        rule =
+        """
+        { "num": ["F0.14"] }
+        """
+        
+        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "num": ["0...14"] }
+        """
+        
+        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "num": ["2.1.4"] }
+        """
+        
+        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
     }
 
 }

--- a/Tests/jsonlogicTests/NumberCastTests.swift
+++ b/Tests/jsonlogicTests/NumberCastTests.swift
@@ -48,35 +48,35 @@ class NumberCastTests: XCTestCase {
         { "num": ["Hello World"] }
         """
         
-        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
+        XCTAssertThrowsError(try applyRule(rule, to: nil) as Optional<Any>)
         
         rule =
         """
         { "num": ["0.14AF"] }
         """
         
-        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
+        XCTAssertThrowsError(try applyRule(rule, to: nil) as Optional<Any>)
 
         rule =
         """
         { "num": ["F0.14"] }
         """
         
-        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
-        
+        XCTAssertThrowsError(try applyRule(rule, to: nil) as Optional<Any>)
+
         rule =
         """
         { "num": ["0...14"] }
         """
         
-        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
-        
+        XCTAssertThrowsError(try applyRule(rule, to: nil) as Optional<Any>)
+
         rule =
         """
         { "num": ["2.1.4"] }
         """
         
-        XCTAssertEqual(JSON.Null, try applyRule(rule, to: nil))
+        XCTAssertThrowsError(try applyRule(rule, to: nil) as Optional<Any>)
     }
 
 }

--- a/Tests/jsonlogicTests/NumberCastTests.swift
+++ b/Tests/jsonlogicTests/NumberCastTests.swift
@@ -25,6 +25,14 @@ class NumberCastTests: XCTestCase {
         """
         
         XCTAssertEqual(0.145, try applyRule(rule, to: nil), accuracy: 0.002)
+        
+        rule =
+        """
+        { "num": [".145"] }
+        """
+        
+        XCTAssertEqual(0.145, try applyRule(rule, to: nil), accuracy: 0.002)
+
 
         rule =
         """

--- a/Tests/jsonlogicTests/NumericalOperations/RoundingTests.swift
+++ b/Tests/jsonlogicTests/NumericalOperations/RoundingTests.swift
@@ -40,4 +40,33 @@ class RoundingTests: XCTestCase {
         XCTAssertEqual(0.0, try applyRule(rule, to: nil))
     }
 
+    func testRounding_oneDecimal() {
+        var rule =
+        """
+        { "rnd": [1.234, 1] }
+        """
+        
+        XCTAssertEqual(1.2, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "rnd": [1.789, 1] }
+        """
+        
+        XCTAssertEqual(1.8, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "rnd": [-0.7, 1] }
+        """
+        
+        XCTAssertEqual(-0.7, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "rnd": [-0.445, 1] }
+        """
+        
+        XCTAssertEqual(-0.4, try applyRule(rule, to: nil))
+    }
 }

--- a/Tests/jsonlogicTests/NumericalOperations/RoundingTests.swift
+++ b/Tests/jsonlogicTests/NumericalOperations/RoundingTests.swift
@@ -16,28 +16,28 @@ class RoundingTests: XCTestCase {
         { "rnd": [1.234, 0] }
         """
         
-        XCTAssertEqual(1, try applyRule(rule, to: nil))
+        XCTAssertEqual(1.0, try applyRule(rule, to: nil))
         
         rule =
         """
         { "rnd": [1.789, 0] }
         """
         
-        XCTAssertEqual(2, try applyRule(rule, to: nil))
+        XCTAssertEqual(2.0, try applyRule(rule, to: nil))
         
         rule =
         """
         { "rnd": [-0.7, 0] }
         """
         
-        XCTAssertEqual(-1, try applyRule(rule, to: nil))
+        XCTAssertEqual(-1.0, try applyRule(rule, to: nil))
         
         rule =
         """
         { "rnd": [-0.4, 0] }
         """
         
-        XCTAssertEqual(0, try applyRule(rule, to: nil))
+        XCTAssertEqual(0.0, try applyRule(rule, to: nil))
     }
 
 }

--- a/Tests/jsonlogicTests/NumericalOperations/RoundingTests.swift
+++ b/Tests/jsonlogicTests/NumericalOperations/RoundingTests.swift
@@ -1,0 +1,43 @@
+//
+//  RoundingTests.swift
+//  jsonlogicTests
+//
+//  Created by Dino on 22/07/2019.
+//
+
+import XCTest
+@testable import jsonlogic
+
+class RoundingTests: XCTestCase {
+
+    func testRounding_noDecimals() {
+        var rule =
+        """
+        { "rnd": [1.234, 0] }
+        """
+        
+        XCTAssertEqual(1, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "rnd": [1.789, 0] }
+        """
+        
+        XCTAssertEqual(2, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "rnd": [-0.7, 0] }
+        """
+        
+        XCTAssertEqual(-1, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "rnd": [-0.4, 0] }
+        """
+        
+        XCTAssertEqual(0, try applyRule(rule, to: nil))
+    }
+
+}

--- a/Tests/jsonlogicTests/NumericalOperations/RoundingTests.swift
+++ b/Tests/jsonlogicTests/NumericalOperations/RoundingTests.swift
@@ -69,4 +69,34 @@ class RoundingTests: XCTestCase {
         
         XCTAssertEqual(-0.4, try applyRule(rule, to: nil))
     }
+    
+    func testRounding_twoDecimals() {
+        var rule =
+        """
+        { "rnd": [1.234, 2] }
+        """
+        
+        XCTAssertEqual(1.23, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "rnd": [1.789, 2] }
+        """
+        
+        XCTAssertEqual(1.79, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "rnd": [-0.799, 1] }
+        """
+        
+        XCTAssertEqual(-0.80, try applyRule(rule, to: nil))
+        
+        rule =
+        """
+        { "rnd": [-0.495, 1] }
+        """
+        
+        XCTAssertEqual(-0.50, try applyRule(rule, to: nil))
+    }
 }

--- a/jsonlogic.podspec
+++ b/jsonlogic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "jsonlogic"
-  s.version = "1.0.0"
+  s.version = "1.1.0"
   s.summary = "A JsonLogic Swift library"
   s.description = "A JsonLogic implementation in Swift. JsonLogic is a way to write rules that involve computations in JSON format, these can be applied on JSON data with consistent results. So you can share between server and clients rules in a common format."
   s.homepage = "https://github.com/advantagefse/json-logic-swift"


### PR DESCRIPTION
I've added trigonometric functions, rounding a number to a specified number of decimal places, and casting a string to a number.

These fall outside of the specification of JSON Logic, but I've found them to be useful for the project I'm working on, so I've created this pull request to see if they would be useful in general.