### PR TITLE
Fixed array path in json logic rule

### DIFF
--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -335,14 +335,22 @@ struct Var: Expression {
             return JSON.Null
         }
 
-        let variablePath = try evaluateVarPathFromData(data)
-        if let variablePathParts = variablePath?.split(separator: ".").map({String($0)}) {
-            var partialResult: JSON? = data
-            for key in variablePathParts {
+      let variablePath = try evaluateVarPathFromData(data)
+      if let variablePathParts = variablePath?.split(separator: ".").map({String($0)}) {
+          var partialResult: JSON? = data
+          for key in variablePathParts {
+              if partialResult?.type == .array {
+                if let index = Int(key), let maxElement = partialResult?.array?.count,  index < maxElement, index >= 0  {
+                  partialResult = partialResult?[index]
+                } else {
+                  partialResult = partialResult?[key]
+                }
+              } else {
                 partialResult = partialResult?[key]
-            }
-            return partialResult ?? JSON.Null
-        }
+              }
+          }
+          return partialResult ?? JSON.Null
+      }
 
         return JSON.Null
     }

--- a/Tests/jsonlogicTests/AccessingDataOperations/ArrayMapTests.swift
+++ b/Tests/jsonlogicTests/AccessingDataOperations/ArrayMapTests.swift
@@ -194,4 +194,16 @@ class ArrayMapTests: XCTestCase {
                 """
         XCTAssertEqual(emptyIntArray, try applyRule(rule))
     }
+  
+    func testAccessingVariableWithArrayIndexPath() {
+      let rule =
+        """
+        { "var" : "person.name.0" }
+        """
+      let data =
+        """
+        { "person" : { "name" : ["John", "Green"] } }
+        """
+        XCTAssertEqual("John", try applyRule(rule, to: data))
+    }
 }


### PR DESCRIPTION
fixed to parsing rule array with index like "payload.r.0.fr" 