### PR TITLE
DoubleNegation value parse

### DIFF
--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -684,7 +684,7 @@ class Parser {
             }
             return LogicalAndOr(isAnd: key == "and", arg: array)
         case "!!":
-            return DoubleNegation(arg: try self.parse(json: value[0]))
+            return DoubleNegation(arg: try self.parse(json: value))
         case "max":
              return Max(arg: try self.parse(json: value))
         case "min":


### PR DESCRIPTION
Supplying `value[0]` in `DoubleNegation` mapping presumed that value is `array`, which isn't necessarily true. For example for this case the mapping failed and threw `.Error(.notSubscriptableType(self.type))`

```
{
  "!!": {
    "missing": [
      "country"
    ]
  }
}
```

Was `value[0]` supplied for any specific purpose?