### PR TITLE
Add support for number lookup in expression IN

### DIFF
--- a/Tests/jsonlogicTests/StringOperations/InTests.swift
+++ b/Tests/jsonlogicTests/StringOperations/InTests.swift
@@ -43,4 +43,32 @@ class InTests: XCTestCase {
         """
         XCTAssertEqual(false, try applyRule(rule, to: nil))
     }
+    
+    func testIn_IntegerArgument() {
+        var rule =
+        """
+        {"in":[5,[-1,0,1,2,3,4,5]]}
+        """
+        XCTAssertEqual(true, try applyRule(rule, to: nil))
+
+        rule =
+        """
+        {"in":[5,[-0,0,1,2,3,4,6]]}
+        """
+        XCTAssertEqual(false, try applyRule(rule, to: nil))
+    }
+    
+    func testIn_DoubleArgument() {
+        var rule =
+        """
+        {"in":[5.1,[1.2,2.5,3.5,4.333,5.1]]}
+        """
+        XCTAssertEqual(true, try applyRule(rule, to: nil))
+
+        rule =
+        """
+        {"in":[5.1,[1.2,2,2.5,3.5,4.333,5]]}
+        """
+        XCTAssertEqual(false, try applyRule(rule, to: nil))
+    }
 }


### PR DESCRIPTION
## Details

Currently, the library does not support lookup for numbers in arrays, only Strings. 

As an example, the Rule and Data below works correctly when we try it on the [JsonLogic](https://jsonlogic.com/play.html) website, but not in this library.

### Rule
`{
  "if": [
    {
      "some" : [ 
          {"var" : ""},
          {
            "and": [
                { "==": [{ "var": "id" }, "123"] },
                {
                  "all" : [
                    {
                      "map": [
                        {"var":"componentAttributes.options"},
                        { "var": "value"}
                      ]
                    },
                    {
                      "in":[{"var":""}, [1, 2] ]
                    }
                  ]
                }
            ]
          }
        ]
    },
    5
  ]
}`

### Data
`[
  {
    "id": "123",
    "componentAttributes":{
      "options":[
        {
          "value":1
        },
        {
          "value":2
        }
      ]
    }
  }
]`

## Fix

I'm adding Integer and Double values support in the `IN` expression.