### PR TITLE
Add support for bool lookup in expression IN

### DIFF
--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -299,6 +299,8 @@ struct In: Expression {
                 return JSON(arrayToSearchIn.contains(JSON(integerToFind)))
             } else if let doubleToFind = try targetExpression.evalWithData(data).double {
                 return JSON(arrayToSearchIn.contains(JSON(doubleToFind)))
+            } else if let boolToFind = try targetExpression.evalWithData(data).bool {
+                return JSON(arrayToSearchIn.contains(JSON(boolToFind)))
             }
         }
         return JSON.Bool(false)

--- a/Tests/jsonlogicTests/StringOperations/InTests.swift
+++ b/Tests/jsonlogicTests/StringOperations/InTests.swift
@@ -71,4 +71,18 @@ class InTests: XCTestCase {
         """
         XCTAssertEqual(false, try applyRule(rule, to: nil))
     }
+
+    func testIn_BoolArgument() {
+        var rule =
+        """
+        {"in":[true,[false, true, false]]}
+        """
+        XCTAssertEqual(true, try applyRule(rule, to: nil))
+
+        rule =
+        """
+        {"in":[true,[false, false, false]]}
+        """
+        XCTAssertEqual(false, try applyRule(rule, to: nil))
+    }
 }


### PR DESCRIPTION
# Details 
The library currently doesn't support lookup for bools in arrays for the `in` expression. 

For example, if you use this rule on the [JsonLogic website](https://jsonlogic.com/play.html) with null data, it will evaluate to `true`. But with this library it will evaluate to `false` because it currently doesn't support looking for bools. 

**Rule**
```
{
     "in":[
         true,
         [true, false]
    ]
}
```

# Fix 

Add support to find bools when evaluating the `in` expression. 