### PR TITLE
fix: divide by zero now does not crash

### DIFF
--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -258,15 +258,27 @@ public enum JSON: Equatable {
     public static func / (lhs: JSON, rhs: JSON) -> JSON {
         switch (lhs, rhs) {
         case let (.Double(x), .Double(y)):
+            guard y != 0 else {
+                return JSON.Null
+            }
             return .Double(x / y)
         case let (.Int(x), .Int(y)):
+            guard y != 0 else {
+                return JSON.Null
+            }
             if x % y == 0 {
                 return .Int(x / y)
             }
             return .Double(Swift.Double(x) / Swift.Double(y))
         case let (.Double(x), .Int(y)):
+            guard y != 0 else {
+                return JSON.Null
+            }
             return .Double(x / Swift.Double(y))
         case let (.Int(x), .Double(y)):
+            guard y != 0 else {
+                return JSON.Null
+            }
             return .Double(Swift.Double(x) / y)
         default:
             return JSON.Null
@@ -276,12 +288,24 @@ public enum JSON: Equatable {
     public static func % (lhs: JSON, rhs: JSON) -> JSON {
         switch (lhs, rhs) {
         case let (.Double(x), .Double(y)):
+            guard y != 0 else {
+                return JSON.Null
+            }
             return .Double(x.truncatingRemainder(dividingBy: y))
         case let (.Int(x), .Int(y)):
+            guard y != 0 else {
+                return JSON.Null
+            }
             return .Int(x % y)
         case let (.Double(x), .Int(y)):
+            guard y != 0 else {
+                return JSON.Null
+            }
             return .Double(x.truncatingRemainder(dividingBy: Swift.Double(y)))
         case let (.Int(x), .Double(y)):
+            guard y != 0 else {
+                return JSON.Null
+            }
             return .Double(Swift.Double(x).truncatingRemainder(dividingBy: y))
         default:
             return JSON.Null

--- a/Tests/jsonlogicTests/ArithmeticTests.swift
+++ b/Tests/jsonlogicTests/ArithmeticTests.swift
@@ -134,6 +134,20 @@ class Arithmetic: XCTestCase {
         XCTAssertEqual(1, try applyRule(rule, to: nil))
     }
 
+    func testDivisionByZero() {
+        let rule =
+        """
+        { "/" : [4, 0]}
+        """
+        XCTAssertThrowsError(try applyRule(rule, to: nil) as Double) { error in
+            XCTAssertEqual(error as! JSONLogicError, JSONLogicError.canNotConvertResultToType(Double.self))
+        }
+
+        XCTAssertThrowsError(try applyRule(rule, to: nil) as Int) { error in
+            XCTAssertEqual(error as! JSONLogicError, JSONLogicError.canNotConvertResultToType(Int.self))
+        }
+    }
+
     func testModulo() {
         var rule =
                 """
@@ -152,6 +166,20 @@ class Arithmetic: XCTestCase {
                 { "%" : [3, 2]}
                 """
         XCTAssertEqual(1, try applyRule(rule, to: nil))
+    }
+
+    func testModuloByZero() {
+        let rule =
+        """
+        { "%" : [4, 0]}
+        """
+        XCTAssertThrowsError(try applyRule(rule, to: nil) as Double) { error in
+            XCTAssertEqual(error as! JSONLogicError, JSONLogicError.canNotConvertResultToType(Double.self))
+        }
+
+        XCTAssertThrowsError(try applyRule(rule, to: nil) as Int) { error in
+            XCTAssertEqual(error as! JSONLogicError, JSONLogicError.canNotConvertResultToType(Int.self))
+        }
     }
 
     func testUnaryMinus() {


### PR DESCRIPTION
Hello,

Thank you for this library.

## Bug Fix: Division by Zero

I have identified a runtime crash issue caused by division by zero. For instance, the following code snippet causes the library to crash:

```swift
let rule =
"""
{ "/" : [10, 0] }
"""

// Example parsing
let result: String? = try? JSONLogicClient.applyRule(rule, to: nil)

print("result = \(String(describing: result))")
```
This pull request implements a fix to prevent this crash.


## Additional Observations


1. Handling Nullable Operands in Arithmetic Operations:

There are similar crashes when operands are null. For example:

```swift
let rule =
"""
{ "/" : [10, null] }
"""

// Example parsing
let result: String? = try? JSONLogicClient.applyRule(rule, to: nil)

print("result = \(String(describing: result))")
```

This likely happens because `null` is treated as `zero`.

2. Logical Operations with `or` and `null`:

This is a valid expression and returns `true`:

```swift
let rule =
"""
{ "or" : [true, null] }
"""

// Example parsing
let result: String? = try? JSONLogicClient.applyRule(rule, to: nil)

print("result = \(String(describing: result))")
```

3. Logical Operations with `and` and `null`:

However, this expression returns `nil`:

```swift
let rule =
"""
{ "and" : [true, null] }
"""

// Example parsing
let result: String? = try? JSONLogicClient.applyRule(rule, to: nil)

print("result = \(String(describing: result))")
```

It would be beneficial to handle nullable operands more predictably.

Thank you for your time reviewing this pull request.

Best regards,

Alexandre